### PR TITLE
Support servlet session store in native servlets (i.e. Pedestal apps)

### DIFF
--- a/modules/web/src/main/clojure/immutant/web/servlet.clj
+++ b/modules/web/src/main/clojure/immutant/web/servlet.clj
@@ -53,7 +53,9 @@
   (init [_ config]
     (with-tccl (.init servlet config)))
   (service [_ request response]
-    (with-tccl (.service servlet request response)))
+    (with-tccl
+      (binding [current-servlet-request request]
+        (.service servlet request response))))
   (destroy [_]
     (.destroy servlet))
   (getServletConfig [_]


### PR DESCRIPTION
This supports sessions for Pedestal apps and also allows the user to create a simple interceptor that handles the cookie de-duplication normally handled in the ring handler wrapper around the servlet to ring adapter handler.  Builds and tests clean locally for existing immutant tests, verified that the changes work on my system.
