### PR TITLE
Depend on tx manager available rather than if inside immutant.

### DIFF
--- a/modules/messaging/src/main/clojure/immutant/messaging/core.clj
+++ b/modules/messaging/src/main/clojure/immutant/messaging/core.clj
@@ -199,7 +199,7 @@
   (log/debug (str "Creating connection " opts))
   (let [conn (backoff
               10 60000
-              (if (or (tx/active?) (and (in-immutant?) (:xa opts)))
+              (if (or (tx/active?) (and (tx/available?) (:xa opts)))
                 (.createXAConnection (connection-factory opts)
                                      (:username opts)
                                      (:password opts))

--- a/modules/xa/src/main/clojure/immutant/xa/transaction.clj
+++ b/modules/xa/src/main/clojure/immutant/xa/transaction.clj
@@ -53,7 +53,7 @@
 (defn after-completion
  "Register a callback to fire when the current transaction is complete"
  [f]
- (if (util/in-immutant?)
+ (if (available?)
   (.registerSynchronization
    (current)
    (reify
@@ -61,7 +61,7 @@
      (afterCompletion [_ _]
        (f))
      (beforeCompletion [_])))
-  (log/warn "transaction/after-completion called outside of Immutant, ignoring.")))
+  (log/warn "transaction/after-completion called when no tx manager was available, ignoring.")))
 
 
 ;;; The functions that enable the various transactional scope macros


### PR DESCRIPTION
While it may be a lot of work to support running all of immutant with a
custom transaction manager, it seems doable for the messaging sub-system
and these small changes are intended to allow the messaging sub-system
to function as long as there is an injected XA manager available by
changing a few checks to be for an available manager instead of if being
run inside of immutant container.
