### PR TITLE
Wrap the k/v args in a map

### DIFF
--- a/docs/src/org/messaging.org
+++ b/docs/src/org/messaging.org
@@ -164,22 +164,22 @@
      (msg/start "queue.foo"
        :dead-letter-address "queue.dead-letters"
        :max-delivery-attempts 20)
-     
+
      ;; setting options for an existing queue
      (hornetq/set-address-options "queue.foo"
-       :dead-letter-address "queue.dead-letters"
-       :max-delivery-attempts 20)
-     
+       {:dead-letter-address "queue.dead-letters"
+        :max-delivery-attempts 20})
+
      ;; setting options for all queues of a certain prefix
      ;; will match: queue.notifications.ham, queue.notifications.biscuits
      (hornetq/set-address-options "queue.notifications.*"
-       :dead-letter-address "queue.dead-letters"
-       :max-delivery-attempts 20)
-     
+       {:dead-letter-address "queue.dead-letters"
+        :max-delivery-attempts 20})
+
      ;; match *all* destinations
      (hornetq/set-address-options "#"
-       :dead-letter-address "queue.dead-letters"
-       :max-delivery-attempts 20)
+       {:dead-letter-address "queue.dead-letters"
+        :max-delivery-attempts 20})
    #+END_SRC
 
 ** Accessing Destinations Controllers


### PR DESCRIPTION
hq/set-address-options expects a map as its second arg whereas msg/start
takes a variable number of k/v pairs.
