### PR TITLE
Fix issue with run-dmc not respecting options

### DIFF
--- a/web/src/immutant/web/internal.clj
+++ b/web/src/immutant/web/internal.clj
@@ -45,7 +45,8 @@
         opts))))
 
 (defn ^:internal run-dmc* [run handler & options]
-  (let [result (apply run (wrap-dev-middleware handler) options)]
+  (let [result (apply run (wrap-dev-middleware handler) options)
+        options (u/kwargs-or-map->map options)]
     (browse-url (format "http://%s:%s%s"
                   (:host options (:host create-defaults))
                   (:port options (:port create-defaults))


### PR DESCRIPTION
browse-url within run-dmc\* was not properly handling the options passed
to it resulting in the browser always being launched and pointed at
http://localhost:8080.
