### PR TITLE
IMMUTANT-568: no concurrent exec option

### DIFF
--- a/scheduling/src/immutant/scheduling.clj
+++ b/scheduling/src/immutant/scheduling.clj
@@ -182,5 +182,11 @@
   "If true (the default), only one instance of a given job name will
    run in a cluster. See [[schedule]].")
 
+(defoption ^{:arglists '([boolean] [m boolean])} allow-concurrent-exec?
+  "If true (the default), the job is allowed to run concurrently.
+   If false it will be forced to run sequentially on one machine.
+   To disallow concurrent execution cluster wide make sure to also
+   set `(singleton true)`. See [[singleton]].")
+
 (defoption ^{:arglists '([str] [m str])} id
   "Takes a String or keyword to use as the unique id for the job. See [[schedule]].")

--- a/scheduling/src/immutant/scheduling.clj
+++ b/scheduling/src/immutant/scheduling.clj
@@ -182,7 +182,7 @@
   "If true (the default), only one instance of a given job name will
    run in a cluster. See [[schedule]].")
 
-(defoption ^{:arglists '([boolean] [m boolean])} allow-concurrent-exec?
+(defoption ^{:arglists '([boolean] [m boolean])} allow-concurrent-exec
   "If true (the default), the job is allowed to run concurrently.
    If false it will be forced to run sequentially on one machine.
    To disallow concurrent execution cluster wide make sure to also


### PR DESCRIPTION
This solves https://issues.jboss.org/browse/IMMUTANT-568.