### PR TITLE
Fix spelling mistake in immutant.caching.cache docs

### DIFF
--- a/caching/src/immutant/caching.clj
+++ b/caching/src/immutant/caching.clj
@@ -77,7 +77,7 @@
 
    Transactions: caches can participate in transactions when a
    TransactionManager is available. The locking scheme may be either
-   :optimisitic or :pessimistic
+   :optimistic or :pessimistic
 
    * :transactional? - whether the cache is transactional [false]
    * :locking - transactional locking scheme [:optimistic]


### PR DESCRIPTION
Should be `:optimistic`, not `:optimisitic`