### PR TITLE
Update broken link

### DIFF
--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -149,7 +149,7 @@ information on running your application in WildFly, see our
 [Timbre]: https://github.com/ptaoussanis/timbre
 [myriad options]: http://logback.qos.ch/manual/index.html
 [logback.xml]: http://logback.qos.ch/manual/configuration.html
-[default configuration]: https://github.com/projectodd/wunderboss/blob/master/modules/core/src/main/resources/logback-default.xml
+[default configuration]: https://github.com/projectodd/wunderboss/blob/master/core/src/main/resources/logback-default.xml
 [incremental build]: http://immutant.org/builds/2x/
 [logging documentation]: https://docs.jboss.org/author/display/WFLY8/Logging+Configuration
 [WildFly]: http://wildfly.org/


### PR DESCRIPTION
A bunch of files in the wunderboss project moved in this commit:
https://github.com/projectodd/wunderboss/commit/fb0ed61a65c04f731f667553397d49d794f7e41e,
breaking this link.

Note: the "default versions" link in docs/guides/messaging.md may
need to be updated as well someday, but since it's pointing to a branch,
it's fine for now.