### PR TITLE
provide a non-decoded :path-info to ring

### DIFF
--- a/web/test-integration/immutant/web/integ_test.clj
+++ b/web/test-integration/immutant/web/integ_test.clj
@@ -125,6 +125,12 @@
     (is (map? (:headers request)))
     (is (< 3 (count (:headers request))))))
 
+;; IMMUTANT-610
+(marktest test-non-decoded-path-info
+  (let [request (decode (get-body (str (url) "dump/request%2B?query=help")
+                                  :headers {:content-type "text/html; charset=utf-8"}))]
+    (is (= (:path-info request) "/request%2B"))))
+
 (marktest non-existent-query-string-is-nil
   (let [request (decode (get-body (str (url) "dump/request") :headers {:content-type "text/html; charset=utf-8"}))]
     (is (nil? (:query-string request)))))


### PR DESCRIPTION
https://issues.jboss.org/browse/IMMUTANT-610

Adds path-info' in immutant.web.internal.undertow/.servlet to provide a non-URL-decoded :path-info value in the Ring request map. [IMMUTANT-610]

@tobias Sorry, I'm not sure if I did that right as I ended up doing a force push to get this up after rebasing/merging/etc., but the commit history looks clean, and the diff is consistent with what it was previously (and tests pass).  Please take a look and let me know if I screwed anything up.

For reference, previous PR: 
https://github.com/immutant/immutant/pull/22